### PR TITLE
Destroyed auth screens from history after the user logs in.

### DIFF
--- a/src/navigation/navigators/auth.js
+++ b/src/navigation/navigators/auth.js
@@ -27,6 +27,7 @@ export default createStackNavigator(
         navigationOptions: {
             header: null,
             headerTransparent: true,
+            gesturesEnabled: false
         },
     },
 );


### PR DESCRIPTION
- **`Issue #3  (Ability to swipe the main tabs layout back to login on IOS devices)`**

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Destroyed auth screens from history after the user logs in.](https://github.com/bytefury/crater-mobile/issues/3)
